### PR TITLE
Fix for audio dropouts

### DIFF
--- a/AudioOutputI2S.h
+++ b/AudioOutputI2S.h
@@ -26,11 +26,11 @@ inline void AudioOutputI2S::begin(uint pBCLK = 20, uint pWS = 21, uint pDOUT = 2
 
   // ********** I2S **********
   i2s.setBCLK(pBCLK);
-  i2s.setMCLK(pWS);
+  //i2s.setMCLK(pWS);
   i2s.setDATA(pDOUT);
-  i2s.setBitsPerSample(SAMPLE_BITS_DEPTH);
+  i2s.setBitsPerSample(32 /* SAMPLE_BITS_DEPTH */);
   i2s.setFrequency(AUDIO_SAMPLE_RATE);
-  i2s.setBuffers(6, AUDIO_BLOCK_SAMPLES * 8 * sizeof(int16_t) / sizeof(uint32_t));
+  i2s.setBuffers(6, AUDIO_BLOCK_SAMPLES * 8 * sizeof(int32_t) / sizeof(uint32_t));
 
   // start I2S at the sample rate with 16-bits per sample
   if (!i2s.begin()) {
@@ -49,13 +49,13 @@ inline void AudioOutputI2S::update() {
     // When sending 0, some DAC will power off causing a hearable jump from silence to floor noise and cracks,
     // sending 1 is a workaround
     // Tested only with the PCM5100A
-    SAMPLE_TYPE sampleL = inputLeftBlock == NULL || inputLeftBlock->data[i] == 0 ? 1 : inputLeftBlock->data[i] * 0.1;
-    SAMPLE_TYPE sampleR = inputRightBlock == NULL || inputRightBlock->data[i] == 0 ? 1 : inputRightBlock->data[i] * 0.1;
-    if (SAMPLE_BITS_DEPTH == 32) {
-      i2s.write32(sampleL, sampleR);
-    } else if (SAMPLE_BITS_DEPTH == 16) {
-      i2s.write16(sampleL, sampleR);
-    }
+    SAMPLE_TYPE sampleL = inputLeftBlock == NULL || inputLeftBlock->data[i] == 0 ? 1 : inputLeftBlock->data[i];// * 0.1;
+    SAMPLE_TYPE sampleR = inputRightBlock == NULL || inputRightBlock->data[i] == 0 ? 1 : inputRightBlock->data[i];// * 0.1;
+//    if (SAMPLE_BITS_DEPTH == 32) {
+      i2s.write32((int32_t)sampleL*65536, (int32_t)sampleR*65536);
+//    } else if (SAMPLE_BITS_DEPTH == 16) {
+//      i2s.write16(sampleL, sampleR);
+//    }
   }
   
   if (inputLeftBlock) {

--- a/AudioOutputI2S.h
+++ b/AudioOutputI2S.h
@@ -33,8 +33,8 @@ inline void AudioOutputI2S::begin(uint pBCLK = 20, uint pWS = 21, uint pDOUT = 2
   i2s.setFrequency(AUDIO_SAMPLE_RATE);
   i2s.setBuffers(6, AUDIO_BLOCK_SAMPLES * 2 * sizeof(int32_t) / sizeof(uint32_t));
   
-pinMode(15,OUTPUT);  
-i2s.onTransmit(I2S_Transmitted);
+// pinMode(15,OUTPUT);  
+  i2s.onTransmit(I2S_Transmitted);
 
   // start I2S at the sample rate with 16-bits per sample
   if (!i2s.begin()) {

--- a/AudioOutputI2S.h
+++ b/AudioOutputI2S.h
@@ -31,7 +31,7 @@ inline void AudioOutputI2S::begin(uint pBCLK = 20, uint pWS = 21, uint pDOUT = 2
   i2s.setDATA(pDOUT);
   i2s.setBitsPerSample(32 /* SAMPLE_BITS_DEPTH */);
   i2s.setFrequency(AUDIO_SAMPLE_RATE);
-  i2s.setBuffers(6, AUDIO_BLOCK_SAMPLES * 8 * sizeof(int32_t) / sizeof(uint32_t));
+  i2s.setBuffers(6, AUDIO_BLOCK_SAMPLES * 2 * sizeof(int32_t) / sizeof(uint32_t));
   
 pinMode(15,OUTPUT);  
 i2s.onTransmit(I2S_Transmitted);

--- a/AudioOutputI2S.h
+++ b/AudioOutputI2S.h
@@ -22,6 +22,7 @@ inline AudioOutputI2S::AudioOutputI2S()
   : AudioStream(2, inputQueueArray) {
 }
 
+extern void I2S_Transmitted(void);
 inline void AudioOutputI2S::begin(uint pBCLK = 20, uint pWS = 21, uint pDOUT = 22) {
 
   // ********** I2S **********
@@ -31,6 +32,9 @@ inline void AudioOutputI2S::begin(uint pBCLK = 20, uint pWS = 21, uint pDOUT = 2
   i2s.setBitsPerSample(32 /* SAMPLE_BITS_DEPTH */);
   i2s.setFrequency(AUDIO_SAMPLE_RATE);
   i2s.setBuffers(6, AUDIO_BLOCK_SAMPLES * 8 * sizeof(int32_t) / sizeof(uint32_t));
+  
+pinMode(15,OUTPUT);  
+i2s.onTransmit(I2S_Transmitted);
 
   // start I2S at the sample rate with 16-bits per sample
   if (!i2s.begin()) {

--- a/AudioStream.cpp
+++ b/AudioStream.cpp
@@ -415,24 +415,7 @@ bool AudioStream::update_scheduled = false;
 
 bool AudioStream::update_setup(void) {
   if (update_scheduled) return false;
-  // attachInterruptVector(IRQ_SOFTWARE, software_isr);
-  // NVIC_SET_PRIORITY(IRQ_SOFTWARE, 208); // 255 = lowest priority
-  // NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
-
-#if 0
-  // ********** Timer **********
-  // Calculate the interval in microseconds , for 48Khz sampling rate -> 375Hz
-  uint64_t interval_us = 1000000 / (AUDIO_SAMPLE_RATE / AUDIO_BLOCK_SAMPLES);
-
-  // Set up the hardware timer with precise timing
-  uint64_t target_time = time_us_64() + interval_us;
-  hardware_alarm_set_callback(0, AudioStream::onTimer);
-  if (!hardware_alarm_set_target(0, target_time)) {
-    Serial.println("Failed to set up timer!");
-  }
-#endif // 0
-
-#if 1
+  
 #define AUDIO_IRQ_PRIORITY 0xD0 // only 4 bits significant on RP2350
 	int tmp = user_irq_claim_unused(false);
 	if (tmp >= 0)
@@ -442,26 +425,24 @@ bool AudioStream::update_setup(void) {
 		irq_set_enabled(tmp,true);
 		user_irq_num = tmp; // do last in case buffer empties during setup!
 	}
-#endif // 1
-
-
-  // Initialize the timer
-  // repeating_timer_t timer;
-  // int32_t interval_us = -1000000 / (AUDIO_SAMPLE_RATE / AUDIO_BLOCK_SAMPLES);
-  // // Set up a repeating timer that calls 'alarm_callback' every 1 second
-  // Serial.println(add_repeating_timer_us(interval_us, AudioStream::onTimer, NULL, &timer));
 
 #define UPDATE_PIN 14
 pinMode(UPDATE_PIN,OUTPUT);
-
 
   update_scheduled = true;
   return true;
 }
 
-void AudioStream::update_stop(void) {
-  // NVIC_DISABLE_IRQ(IRQ_SOFTWARE);
-  update_scheduled = false;
+void AudioStream::update_stop(void) 
+{
+	int tmp = user_irq_num;
+
+	user_irq_num = -1; // do first in case buffer empties during teardown!
+	irq_set_enabled(tmp,false);
+	irq_remove_handler(tmp,software_isr);
+	user_irq_unclaim(tmp);
+	
+	update_scheduled = false;
 }
 
 AudioStream *AudioStream::first_update = NULL;
@@ -499,20 +480,6 @@ digitalWrite(UPDATE_PIN,1);
 digitalWrite(UPDATE_PIN,0);	  
 }
 
-
-void AudioStream::onTimer(uint alarm_num) {
-// bool AudioStream::onTimer(repeating_timer_t* timer) {
-  // Schedule the next callback
-  uint64_t interval_us = 1000000 / (AUDIO_SAMPLE_RATE / AUDIO_BLOCK_SAMPLES);
-  uint64_t next_time = time_us_64() + interval_us;
-  hardware_alarm_set_target(alarm_num, next_time);
-
-  // if (i2s.availableForWrite() >= AUDIO_BLOCK_SAMPLES) {
-  AudioStream::update_all();
-  // }
-
-  // return true;
-}
 
 void I2S_Transmitted(void)
 {

--- a/AudioStream.cpp
+++ b/AudioStream.cpp
@@ -435,6 +435,9 @@ bool AudioStream::update_setup(void) {
   // // Set up a repeating timer that calls 'alarm_callback' every 1 second
   // Serial.println(add_repeating_timer_us(interval_us, AudioStream::onTimer, NULL, &timer));
 
+#define UPDATE_PIN 14
+pinMode(UPDATE_PIN,OUTPUT);
+
 
   update_scheduled = true;
   return true;
@@ -482,8 +485,18 @@ void AudioStream::onTimer(uint alarm_num) {
   hardware_alarm_set_target(alarm_num, next_time);
 
   // if (i2s.availableForWrite() >= AUDIO_BLOCK_SAMPLES) {
+digitalWrite(UPDATE_PIN,1);	  
   AudioStream::update_all();
+digitalWrite(UPDATE_PIN,0);
   // }
 
   // return true;
+}
+
+void I2S_Transmitted(void)
+{
+#define UPDATE_I2S 15
+	static bool ps = false;
+	digitalWrite(UPDATE_I2S, ps);
+	ps = !ps;
 }

--- a/AudioStream.cpp
+++ b/AudioStream.cpp
@@ -418,6 +418,7 @@ bool AudioStream::update_setup(void) {
   // NVIC_SET_PRIORITY(IRQ_SOFTWARE, 208); // 255 = lowest priority
   // NVIC_ENABLE_IRQ(IRQ_SOFTWARE);
 
+#if 0
   // ********** Timer **********
   // Calculate the interval in microseconds , for 48Khz sampling rate -> 375Hz
   uint64_t interval_us = 1000000 / (AUDIO_SAMPLE_RATE / AUDIO_BLOCK_SAMPLES);
@@ -428,6 +429,7 @@ bool AudioStream::update_setup(void) {
   if (!hardware_alarm_set_target(0, target_time)) {
     Serial.println("Failed to set up timer!");
   }
+#endif // 0
 
   // Initialize the timer
   // repeating_timer_t timer;
@@ -452,6 +454,7 @@ AudioStream *AudioStream::first_update = NULL;
 
 // void software_isr(void) // AudioStream::update_all()
 void AudioStream::update_all(void) {
+digitalWrite(UPDATE_PIN,1);	  
   AudioStream *p;
 
   // uint32_t totalcycles = ARM_DWT_CYCCNT;
@@ -474,6 +477,7 @@ void AudioStream::update_all(void) {
   // 	AudioStream::cpu_cycles_total_max = totalcycles;
 
   // asm("DSB");
+digitalWrite(UPDATE_PIN,0);	  
 }
 
 
@@ -485,9 +489,7 @@ void AudioStream::onTimer(uint alarm_num) {
   hardware_alarm_set_target(alarm_num, next_time);
 
   // if (i2s.availableForWrite() >= AUDIO_BLOCK_SAMPLES) {
-digitalWrite(UPDATE_PIN,1);	  
   AudioStream::update_all();
-digitalWrite(UPDATE_PIN,0);
   // }
 
   // return true;
@@ -499,4 +501,5 @@ void I2S_Transmitted(void)
 	static bool ps = false;
 	digitalWrite(UPDATE_I2S, ps);
 	ps = !ps;
+	AudioStream::update_all(); // sync updates with buffer transfer
 }

--- a/AudioStream.cpp
+++ b/AudioStream.cpp
@@ -426,8 +426,8 @@ bool AudioStream::update_setup(void) {
 		user_irq_num = tmp; // do last in case buffer empties during setup!
 	}
 
-#define UPDATE_PIN 14
-pinMode(UPDATE_PIN,OUTPUT);
+// #define UPDATE_PIN 14
+// pinMode(UPDATE_PIN,OUTPUT);
 
   update_scheduled = true;
   return true;
@@ -454,7 +454,7 @@ void software_isr(void)
 
 // void software_isr(void) // AudioStream::update_all()
 void AudioStream::update_all(void) {
-digitalWrite(UPDATE_PIN,1);	  
+// digitalWrite(UPDATE_PIN,1);	  
   AudioStream *p;
 
   // uint32_t totalcycles = ARM_DWT_CYCCNT;
@@ -477,16 +477,18 @@ digitalWrite(UPDATE_PIN,1);
   // 	AudioStream::cpu_cycles_total_max = totalcycles;
 
   // asm("DSB");
-digitalWrite(UPDATE_PIN,0);	  
+// digitalWrite(UPDATE_PIN,0);	  
 }
 
 
 void I2S_Transmitted(void)
 {
+/*
 #define UPDATE_I2S 15
 	static bool ps = false;
 	digitalWrite(UPDATE_I2S, ps);
 	ps = !ps;
+*/
 	
 	if (AudioStream::user_irq_num >= 0)
 		irq_set_pending(AudioStream::user_irq_num);

--- a/AudioStream.h
+++ b/AudioStream.h
@@ -170,11 +170,8 @@ protected:
 	audio_block_t * receiveWritable(unsigned int index = 0);
 	static bool update_setup(void);
 	static void update_stop(void);
-	// static void update_all(void) {NVIC_SET_PENDING(IRQ_SOFTWARE);}
 	static void update_all(void);
-	friend void I2S_Transmitted(void); // used to call update_all()
-  static void onTimer(uint alarm_um);
-  // static bool onTimer(repeating_timer_t* timer);
+	friend void I2S_Transmitted(void); // used to trigger update_all()
 	friend void software_isr(void);
 	static int user_irq_num;
 	friend class AudioConnection;

--- a/AudioStream.h
+++ b/AudioStream.h
@@ -171,6 +171,7 @@ protected:
 	static void update_stop(void);
 	// static void update_all(void) {NVIC_SET_PENDING(IRQ_SOFTWARE);}
 	static void update_all(void);
+	friend void I2S_Transmitted(void); // used to call update_all()
   static void onTimer(uint alarm_um);
   // static bool onTimer(repeating_timer_t* timer);
 	friend void software_isr(void);

--- a/AudioStream.h
+++ b/AudioStream.h
@@ -128,7 +128,8 @@ class AudioStream
 {
 public:
 	AudioStream(unsigned char ninput, audio_block_t **iqueue) :
-		num_inputs(ninput), inputQueue(iqueue) {
+		num_inputs(ninput), inputQueue(iqueue)
+		{
 			active = false;
 			destination_list = NULL;
 			for (int i=0; i < num_inputs; i++) {
@@ -175,6 +176,7 @@ protected:
   static void onTimer(uint alarm_um);
   // static bool onTimer(repeating_timer_t* timer);
 	friend void software_isr(void);
+	static int user_irq_num;
 	friend class AudioConnection;
 #if defined(AUDIO_DEBUG_CLASS)
 	friend class AudioDebug;

--- a/AudioStream.h
+++ b/AudioStream.h
@@ -59,6 +59,9 @@
 #endif
 
 #define AUDIO_SAMPLE_RATE 48000
+#define SAMPLE_TYPE int16_t
+#define SAMPLE_BITS_DEPTH 16
+
 
 #define noAUDIO_DEBUG_CLASS // disable this class by default
 


### PR DESCRIPTION
Uses a similar scheme to Teensy; I²S buffer transfers result in a callback, which triggers a low-priority "user" interrupt, which then does the update. This means it's guaranteed that updates happen in sync with I²S output, so there should be no over- or under-runs. We can also control the priority of the user interrupt, which we can't / shouldn't with the I²S interrupt, and also shouldn't `update()` directly in the callback.

For some reason my hardware didn't like the 16-bit transfers, so I've hacked things about to transfer 32 bits per channel, with the lowest 16 bits set to zero. CAUTION! I also removed the multiplication of the incoming data by 0.1, as I couldn't see anything on the 'scope otherwise.