### PR TITLE
make I2S declaration public

### DIFF
--- a/AudioOutputI2S.h
+++ b/AudioOutputI2S.h
@@ -6,11 +6,11 @@
 #include "AudioStream.h"
 
 class AudioOutputI2S : public AudioStream {
-public:
-  static I2S i2s;
+protected:
   audio_block_t *inputQueueArray[2];
 
 public:
+  static I2S i2s;
   AudioOutputI2S();
   void begin(uint pBCLK, uint pWS, uint pDOUT);
   void update();

--- a/AudioOutputI2S.h
+++ b/AudioOutputI2S.h
@@ -6,7 +6,7 @@
 #include "AudioStream.h"
 
 class AudioOutputI2S : public AudioStream {
-protected:
+public:
   static I2S i2s;
   audio_block_t *inputQueueArray[2];
 


### PR DESCRIPTION
Hello! I hope you are doing well!
I have request for a small change in the pico-audio library.

If on a board the Codec is wired in a different pin order, with descending pin numbers for BCLK, LRCK and DAC, you can call swapClocks(); from the I2S.h core library to initialize I2S with the correct PIO program.

This will only work if the I2S declaration is public, it is currently declared protected.

It would be great to make this small change, it helped get a board running with rp2350B and a TI codec (AIC3204) codec from TI.